### PR TITLE
fix: redirect registered users to home page

### DIFF
--- a/frontend/app/auth/signup/page.tsx
+++ b/frontend/app/auth/signup/page.tsx
@@ -66,7 +66,7 @@ export default function SignupPage() {
   const handleTransitionComplete = () => {
     // Navigate to the appropriate page after transition completes
     const pendingLearningPlanId = sessionStorage.getItem('pendingLearningPlanId');
-    const redirectTarget = pendingLearningPlanId ? '/speech' : '/language-selection';
+    const redirectTarget = pendingLearningPlanId ? '/speech' : '/';
     console.log(`Transition complete, navigating to ${redirectTarget}`);
     router.push(redirectTarget);
   };


### PR DESCRIPTION

- Updated signup page to redirect to home page (/) instead of /language-selection after Google signup
- Users now see their learning journey dashboard immediately after authentication
- Manual navigation to language selection still works for starting new sessions