### PR TITLE
Fix current week logic: Week 2 now shows as BLUE (in-progress)

### DIFF
--- a/frontend/components/dashboard/LearningPlanDetailsModal.tsx
+++ b/frontend/components/dashboard/LearningPlanDetailsModal.tsx
@@ -343,9 +343,23 @@ export const LearningPlanDetailsModal: React.FC<LearningPlanDetailsModalProps> =
                           weekStatus = 'current';
                           weekProgress = (weekSessionsCompleted / weekTotalSessions) * 100;
                         } else {
-                          // Week is upcoming
-                          weekStatus = 'upcoming';
-                          weekProgress = 0;
+                          // Check if this is the next week after the last completed week
+                          const previousWeek = weeklySchedule.find(w => w.week === week.week - 1);
+                          if (!previousWeek) {
+                            // This is week 1 and no previous week exists
+                            weekStatus = 'current';
+                            weekProgress = 0;
+                          } else {
+                            // Check if previous week is completed
+                            const prevWeekCompleted = (previousWeek.sessions_completed || 0) >= (previousWeek.total_sessions || 2);
+                            if (prevWeekCompleted) {
+                              weekStatus = 'current';
+                              weekProgress = 0;
+                            } else {
+                              weekStatus = 'upcoming';
+                              weekProgress = 0;
+                            }
+                          }
                         }
                         
                         const isCompleted = weekStatus === 'completed';


### PR DESCRIPTION
## Issue Fixed
Week 2 with 0/2 sessions was showing as GRAY (upcoming) instead of BLUE (in-progress). According to the user feedback, Week 2 should be the current week in progress since Week 1 is completed.

## Root Cause
The logic was only considering weeks with `sessions_completed > 0` as current weeks. However, the current week should be the **next week to work on** after the last completed week, even if no sessions have been started yet.

## Solution
Updated the current week determination logic:

### Before
```typescript
const isCurrentWeek = weekSessionsCompleted > 0 && weekSessionsCompleted < weekTotalSessions;
```

### After
```typescript
// Week is current if:
// 1. It has some sessions but not completed (in progress)
// 2. It has 0 sessions but is the next week after the last completed week
if (weekSessionsCompleted > 0 && weekSessionsCompleted < weekTotalSessions) {
  isCurrentWeek = true;
} else if (weekSessionsCompleted === 0) {
  const previousWeek = allWeeks.find(w => w.week === week.week - 1);
  if (!previousWeek || (previousWeek.sessions_completed || 0) >= (previousWeek.total_sessions || 2)) {
    isCurrentWeek = true;
  }
}
```

## Expected Behavior
- **Week 1 (2/2 sessions)**: **GREEN** ✅ (Completed)
- **Week 2 (0/2 sessions)**: **BLUE** 🔄 (Current/In-Progress) 
- **Week 3+ (0/2 sessions)**: **GRAY** ⏳ (Upcoming)

## Files Updated
- `frontend/components/assessment-learning-plan-card.tsx` - Main weekly schedule display
- `frontend/components/dashboard/LearningPlanDetailsModal.tsx` - Detailed modal view

## Testing
Based on the provided MongoDB data:
- Week 1: `sessions_completed: 2, total_sessions: 2` → GREEN (completed)
- Week 2: `sessions_completed: 0, total_sessions: 2` → BLUE (current week to work on)

This matches the user's expectation that Week 2 should be blue since it's the week in progress after completing Week 1.