### PR TITLE
Hide navigation menu items after user login

### DIFF
--- a/frontend/components/nav-bar.tsx
+++ b/frontend/components/nav-bar.tsx
@@ -188,8 +188,8 @@ export default function NavBar({ activeSection = '' }: { activeSection?: string 
 
         {/* Navigation Links */}
         <div className="hidden md:flex items-center space-x-6">
-          {/* Landing page navigation items */}
-          {isLandingPage && (
+          {/* Landing page navigation items - only show when not logged in */}
+          {isLandingPage && !user && (
             <div className="flex items-center space-x-6 mr-4">
               <button 
                 onClick={() => scrollToSection('features')}
@@ -318,8 +318,8 @@ export default function NavBar({ activeSection = '' }: { activeSection?: string 
       {/* Mobile Menu - Enhanced for better mobile UX */}
       {isMenuOpen && (
         <div className="block md:hidden bg-white/10 backdrop-blur-md border border-white/20 shadow-lg mt-2 mx-4 rounded-lg overflow-hidden mobile-menu-container">
-          {/* Landing page menu items on mobile */}
-          {isLandingPage && (
+          {/* Landing page menu items on mobile - only show when not logged in */}
+          {isLandingPage && !user && (
             <>
               <button
                 onClick={() => scrollToSection('features')}


### PR DESCRIPTION
## Summary
Hides the landing page navigation menu items ("Features", "How it works", "Pricing", "FAQ") when users are logged in, as these items are non-functional for authenticated users.

## Changes
- Modified `frontend/components/nav-bar.tsx` to conditionally hide menu items based on user authentication status
- Applied fix to both desktop and mobile navigation menus
- Menu items now only show on landing page when user is not authenticated

## Technical Details
- Changed condition from `{isLandingPage && (` to `{isLandingPage && !user && (` for both navigation sections
- Improves UX by removing non-functional menu items for logged-in users

## Testing
- ✅ Menu items hidden when user is logged in
- ✅ Menu items visible when user is not logged in (on landing page)
- ✅ Works on both desktop and mobile views